### PR TITLE
fix: use exec to replace pid 1 shell with process

### DIFF
--- a/charts/arbitrum-classic/templates/arbitrum/statefulset.yaml
+++ b/charts/arbitrum-classic/templates/arbitrum/statefulset.yaml
@@ -151,7 +151,7 @@ spec:
               . /env/init-nodeport;
             {{- end }}
               set -ex;
-              arb-node \
+              exec arb-node \
                 --core.checkpoint-gas-frequency=156250000 \
                 --persistent.chain=/storage \
                 --persistent.global-config=/storage \

--- a/charts/arbitrum-nitro/templates/arbitrum-nitro/statefulset.yaml
+++ b/charts/arbitrum-nitro/templates/arbitrum-nitro/statefulset.yaml
@@ -100,7 +100,7 @@ spec:
               . /env/init-nodeport;
             {{- end }}
               set -ex;
-              nitro \
+              exec nitro \
                 --persistent.chain=/storage/data \
                 --persistent.global-config=/storage \
                 --http.addr=0.0.0.0 \

--- a/charts/avalanche/templates/avalanche/statefulset.yaml
+++ b/charts/avalanche/templates/avalanche/statefulset.yaml
@@ -136,7 +136,7 @@ spec:
               . /env/init-nodeport;
             {{- end }}
               set -ex;
-              /avalanchego/build/avalanchego \
+              exec /avalanchego/build/avalanchego \
                 --config-file=/config/config.toml \
                 --data-dir=/storage \
                 --api-metrics-enabled=true \

--- a/charts/celo/templates/celo/statefulset.yaml
+++ b/charts/celo/templates/celo/statefulset.yaml
@@ -100,7 +100,7 @@ spec:
               . /env/init-nodeport;
             {{- end }}
               set -ex;
-              geth \
+              exec geth \
                 --datadir=/storage \
               {{- if $values.p2pNodePort.enabled }}
                 --nat=extip:${EXTERNAL_IP} \

--- a/charts/lighthouse/templates/lighthouse/statefulset.yaml
+++ b/charts/lighthouse/templates/lighthouse/statefulset.yaml
@@ -131,7 +131,7 @@ spec:
               . /env/init-nodeport;
             {{- end }}
               set -ex;
-              lighthouse beacon_node \
+              exec lighthouse beacon_node \
                 --datadir=/storage \
               {{- if $values.executionClientUrl }}
                 --execution-endpoint={{ $values.executionClientUrl }} \


### PR DESCRIPTION
As reported in #51, some containers have a shell as PID 1.

This PR uses `exec` to replace the shell with the invoked process as PID 1.

This doesn't completely solve #51 since PID 1 is expected to handle signals in a way that non-PID 1 processes are not. For that we should still try to roll dumb-init into all images.