### PR TITLE
chore(ci): fix curl lib issue in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     container: quay.io/git-chglog/git-chglog:0.15.0
+    permissions:
+      contents: write # for creating releases
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install main dependencies
         run: |
-          apk add bash git grep yq curl
+          apk --upgrade add bash git grep yq curl
 
       - name: Install Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install main dependencies
         run: |


### PR DESCRIPTION
Release workflow is broken at the moment:
```
Error relocating /usr/bin/curl: curl_easy_nextheader: symbol not found
Error relocating /usr/bin/curl: curl_easy_header: symbol not found
Error: Process completed with exit code 127.
```
The --upgrade addition to apk command fixed it for me. 

Also adding workspace dir to git safe-directories as recent git has become more strict about mismatch between files owner and user id. And add missing permissions for contents write as github became more restrictive by default.

While soon there will be more major changes incoming to the CI stuff, lets unblock the release pipeline in the meanwhile.