### PR TITLE
chore: attempting to fix renovate for arbitrum releases

### DIFF
--- a/charts/arbitrum-classic/Chart.yaml
+++ b/charts/arbitrum-classic/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-# renovate: image=offchainlabs/arb-node
+# renovate: image=docker.io/offchainlabs/arb-node
 appVersion: "v1.4.5-e97c1a4"

--- a/charts/arbitrum-classic/README.md
+++ b/charts/arbitrum-classic/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale [Arbitrum-Classic](https://github.com/OffchainLabs/arbitrum) inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.5-e97c1a4](https://img.shields.io/badge/AppVersion-v1.4.5--e97c1a4-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.5-e97c1a4](https://img.shields.io/badge/AppVersion-v1.4.5--e97c1a4-informational?style=flat-square)
 
 ## Features
 

--- a/charts/arbitrum-nitro/Chart.yaml
+++ b/charts/arbitrum-nitro/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-# renovate: image=offchainlabs/nitro-node
+# renovate: image=docker.io/offchainlabs/nitro-node
 appVersion: "v2.0.10-73224e3"

--- a/charts/arbitrum-nitro/README.md
+++ b/charts/arbitrum-nitro/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale [Arbitrum-Nitro](https://github.com/OffchainLabs/nitro/) inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.10-73224e3](https://img.shields.io/badge/AppVersion-v2.0.10--73224e3-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.10-73224e3](https://img.shields.io/badge/AppVersion-v2.0.10--73224e3-informational?style=flat-square)
 
 ## Features
 


### PR DESCRIPTION
Not 100% why renovate if not picking up new releases for arbitrum - both `docker pull docker.io/offchainlabs/arb-node:"v1.4.5-e97c1a4"` and ` docker pull offchainlabs/arb-node:"v1.4.5-e97c1a4"` work so decided to try this