### PR TITLE
fix(graph-networks-indexer): set replicas for indexer-service

### DIFF
--- a/charts/graph-network-indexer/Chart.yaml
+++ b/charts/graph-network-indexer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/graph-network-indexer/README.md
+++ b/charts/graph-network-indexer/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale the [Graph Network Indexer](https://github.com/graphprotocol/indexer) components inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.20.23](https://img.shields.io/badge/AppVersion-v0.20.23-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.20.23](https://img.shields.io/badge/AppVersion-v0.20.23-informational?style=flat-square)
 
 ## Introduction
 
@@ -96,6 +96,7 @@ We do not recommend that you upgrade the application by overriding `image.tag`. 
  | indexerService.nodeSelector |  | object | `{}` |
  | indexerService.podAnnotations | Annotations for the `Pod` | object | `{}` |
  | indexerService.podSecurityContext | Pod-wide security context | object | `{"fsGroup":101337,"runAsGroup":101337,"runAsNonRoot":true,"runAsUser":101337}` |
+ | indexerService.replicas | Number of replicas to run | int | `1` |
  | indexerService.resources |  | object | `{}` |
  | indexerService.secretEnv |  | object | `{}` |
  | indexerService.service.ports.http-metrics | Service Port to expose Metrics on | int | `7300` |

--- a/charts/graph-network-indexer/templates/indexer-service/deployment.yaml
+++ b/charts/graph-network-indexer/templates/indexer-service/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "graph-network-indexer.labels" . | nindent 4 }}
     {{- $componentLabel | nindent 4 }}
 spec:
-  replicas: 1 # Should only ever be one instance of indexer-agent
+  replicas: {{ $values.replicas }}
   selector:
     matchLabels:
       {{- include "graph-network-indexer.selectorLabels" . | nindent 6 }}

--- a/charts/graph-network-indexer/values.yaml
+++ b/charts/graph-network-indexer/values.yaml
@@ -76,7 +76,7 @@ indexerAgent:
     # -- Overrides the image tag
     # @default -- Chart.appVersion
     tag: ""
-  
+
   # -- Config to be supplied as CLI arguments, specified using YAML keys to allow overriding
   config:
     # -- (required) URL for your graph-node admin API endpoint
@@ -159,6 +159,9 @@ indexerService:
     # -- Overrides the image tag
     # @default -- Chart.appVersion
     tag: ""
+
+  # -- Number of replicas to run
+  replicas: 1
 
   # -- Config to be supplied as CLI arguments, specified using YAML keys to allow overriding
   config:


### PR DESCRIPTION
Hello,

There was an incorrect copy-paste from the indexer-agent (StatefulSet) to the indexer-service (Deployment), which prevented setting more than 1 replica for the service.