### PR TITLE
fix(graph-node): merge of `graphNodeGroups.enabled:false`

### DIFF
--- a/charts/graph-node/templates/graph-node/all.yaml
+++ b/charts/graph-node/templates/graph-node/all.yaml
@@ -6,7 +6,7 @@
      into the graph node config file */}}
 {{- $indexPools := dict }}
 {{- range $groupName, $groupValues := $.Values.graphNodeGroups }}
-  {{- $values := deepCopy $.Values.graphNodeDefaults | mustMerge $groupValues }}
+  {{- $values := deepCopy $groupValues | mustMergeOverwrite $.Values.graphNodeDefaults }}
   {{- if $values.enabled }}
     {{- range $indexPoolName := $values.includeInIndexPools }}
       {{- $indexPoolNodeIds := default list (get $indexPools $indexPoolName) }}


### PR DESCRIPTION
`graphNodeGroups.enabled: false` would always be ignored and treated as `true` because of `merge` bug https://github.com/helm/helm/issues/5238