### PR TITLE
fix(graph-node): per group env vars

### DIFF
--- a/charts/graph-node/Chart.yaml
+++ b/charts/graph-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/graph-node/README.md
+++ b/charts/graph-node/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale [Graph Node](https://github.com/graphprotocol/graph-node) inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.34.1](https://img.shields.io/badge/AppVersion-v0.34.1-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.34.1](https://img.shields.io/badge/AppVersion-v0.34.1-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/graph-node/templates/graph-node/all.yaml
+++ b/charts/graph-node/templates/graph-node/all.yaml
@@ -6,7 +6,7 @@
      into the graph node config file */}}
 {{- $indexPools := dict }}
 {{- range $groupName, $groupValues := $.Values.graphNodeGroups }}
-  {{- $values := deepCopy $groupValues | mustMergeOverwrite $.Values.graphNodeDefaults }}
+  {{- $values := deepCopy $groupValues | mustMergeOverwrite (deepCopy $.Values.graphNodeDefaults) }}
   {{- if $values.enabled }}
     {{- range $indexPoolName := $values.includeInIndexPools }}
       {{- $indexPoolNodeIds := default list (get $indexPools $indexPoolName) }}
@@ -45,7 +45,7 @@ data:
 
 {{/* Finally, we render out the resources for our Graph Node groups */}}
 {{- range $groupName, $groupValues := $.Values.graphNodeGroups }}
-{{- $values := deepCopy $groupValues | mustMergeOverwrite $.Values.graphNodeDefaults }}
+{{- $values := deepCopy $groupValues | mustMergeOverwrite (deepCopy $.Values.graphNodeDefaults) }}
 {{- if $values.enabled }}
 {{- $componentLabel := include "graph-node.componentLabelFor" $groupName }}
 {{/* The outer range seems to mess with the inner context and break helpers.
@@ -214,7 +214,6 @@ spec:
             {{- with $values.extraArgs }}
               {{- toYaml (. | default list) | nindent 12 }}
             {{- end }}
-          {{- if (or $values.env $values.secretEnv) }}
           env:
             - name: NODE_ID
               valueFrom:
@@ -224,6 +223,7 @@ spec:
             - name: DISABLE_BLOCK_INGESTOR
               value: "true"
           {{- end }}
+          {{- if (or $values.env $values.secretEnv) }}
           {{- with $values.env }}
           {{- range $key, $val := .}}
             - name: {{ $key | quote }}


### PR DESCRIPTION
graphNodeDefaults was getting overwritten by `mustMerge`, as that function writes to the destination dictionary besides returning the result for the attribution, so do a deepCopy.

also move the conditional `{{- if (or $values.env $values.secretEnv) }}` a bit further below, as we want the first few env var definitions regardless.

Closes https://github.com/graphops/launchpad-charts/issues/280