### PR TITLE
fix(graph-node): better namespace template

### DIFF
--- a/charts/graph-node/dashboards/query-performance-overview.json
+++ b/charts/graph-node/dashboards/query-performance-overview.json
@@ -1436,7 +1436,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(indexer_service_queries_total,namespace)",
+        "definition": "label_values(indexer_service_channel_messages_total,namespace)",
         "hide": 0,
         "includeAll": false,
         "label": "Namespace",
@@ -1445,7 +1445,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(indexer_service_queries_total,namespace)",
+          "query": "label_values(indexer_service_channel_messages_total,namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
Improves the detection of namespaces containing indexer-service instances. 

Replacing namespace templating query with `indexer_service_channel_messages_total`. 

Before it was based on `indexer_service_queries_total`. The problem with that one is that the metric does not exist at all until the indexer-service gets a query, while `indexer_service_channel_messages_total` always starts out with 0.