### PR TITLE
fix: serviceMonitor should target a single service

### DIFF
--- a/charts/arbitrum-nitro/Chart.yaml
+++ b/charts/arbitrum-nitro/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/arbitrum-nitro/README.md
+++ b/charts/arbitrum-nitro/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale [Arbitrum-Nitro](https://github.com/OffchainLabs/nitro/) inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.2.1-d81324d](https://img.shields.io/badge/AppVersion-v3.2.1--d81324d-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.2.1-d81324d](https://img.shields.io/badge/AppVersion-v3.2.1--d81324d-informational?style=flat-square)
 
 ## Features
 

--- a/charts/arbitrum-nitro/templates/arbitrum-nitro/servicemonitor.yaml
+++ b/charts/arbitrum-nitro/templates/arbitrum-nitro/servicemonitor.yaml
@@ -16,6 +16,7 @@ spec:
     matchLabels:
       {{- include "arbitrum-nitro.selectorLabels" . | nindent 6 }}
       {{- $componentLabel | nindent 6 }}
+      serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
   endpoints:
   - port: http-metrics
     path: /debug/metrics/prometheus

--- a/charts/graph-network-indexer/Chart.yaml
+++ b/charts/graph-network-indexer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/graph-network-indexer/README.md
+++ b/charts/graph-network-indexer/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale the [Graph Network Indexer](https://github.com/graphprotocol/indexer) components inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/graph-network-indexer/templates/indexer-agent/service.yaml
+++ b/charts/graph-network-indexer/templates/indexer-agent/service.yaml
@@ -32,6 +32,7 @@ metadata:
   labels:
     {{- include "graph-network-indexer.labels" . | nindent 4 }}
     {{- $componentLabel | nindent 4 }}
+    serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
 spec:
   type: {{ $values.service.type }}
   ports:

--- a/charts/graph-network-indexer/templates/indexer-agent/servicemonitor.yaml
+++ b/charts/graph-network-indexer/templates/indexer-agent/servicemonitor.yaml
@@ -16,6 +16,7 @@ spec:
     matchLabels:
       {{- include "graph-network-indexer.selectorLabels" . | nindent 6 }}
       {{- $componentLabel | nindent 6 }}
+      serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
   endpoints:
   - port: http-metrics
     {{- with .Values.prometheus.serviceMonitors.interval }}

--- a/charts/graph-network-indexer/templates/indexer-tap-agent/service.yaml
+++ b/charts/graph-network-indexer/templates/indexer-tap-agent/service.yaml
@@ -33,6 +33,7 @@ metadata:
   labels:
     {{- include "graph-network-indexer.labels" . | nindent 4 }}
     {{- $componentLabel | nindent 4 }}
+    serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
 spec:
   type: {{ $values.service.type }}
   ports:

--- a/charts/graph-network-indexer/templates/indexer-tap-agent/servicemonitor.yaml
+++ b/charts/graph-network-indexer/templates/indexer-tap-agent/servicemonitor.yaml
@@ -16,6 +16,7 @@ spec:
     matchLabels:
       {{- include "graph-network-indexer.selectorLabels" . | nindent 6 }}
       {{- $componentLabel | nindent 6 }}
+      serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
   endpoints:
   - port: http-metrics
     {{- with .Values.prometheus.serviceMonitors.interval }}

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.3
+version: 1.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/heimdall/README.md
+++ b/charts/heimdall/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale [Heimdall](https://github.com/maticnetwork/heimdall) inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.10](https://img.shields.io/badge/AppVersion-1.0.10-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 1.2.4](https://img.shields.io/badge/Version-1.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.10](https://img.shields.io/badge/AppVersion-1.0.10-informational?style=flat-square)
 
 ## Features
 

--- a/charts/heimdall/templates/heimdall/service.yaml
+++ b/charts/heimdall/templates/heimdall/service.yaml
@@ -37,6 +37,7 @@ metadata:
   labels:
     {{- include "heimdall.labels" . | nindent 4 }}
     {{- $componentLabel | nindent 4 }}
+    serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
 spec:
   type: {{ $values.service.type }}
   ports:

--- a/charts/heimdall/templates/heimdall/servicemonitor.yaml
+++ b/charts/heimdall/templates/heimdall/servicemonitor.yaml
@@ -16,6 +16,7 @@ spec:
     matchLabels:
       {{- include "heimdall.selectorLabels" . | nindent 6 }}
       {{- $componentLabel | nindent 6 }}
+      serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
   endpoints:
     - port: http-metrics
       {{- with .Values.prometheus.serviceMonitors.interval }}

--- a/charts/listener-radio/Chart.yaml
+++ b/charts/listener-radio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/listener-radio/README.md
+++ b/charts/listener-radio/README.md
@@ -2,7 +2,7 @@
 
 Deploy a Graphcast Listener Radio into your Kubernetes stack
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.4](https://img.shields.io/badge/AppVersion-0.0.4-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.4](https://img.shields.io/badge/AppVersion-0.0.4-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/listener-radio/templates/listener-radio/servicemonitor.yaml
+++ b/charts/listener-radio/templates/listener-radio/servicemonitor.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "listener-radio.selectorLabels" . | nindent 6 }}
+      serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
   endpoints:
   - port: http-metrics
     {{- with .Values.service.serviceMonitors.interval }}

--- a/charts/subgraph-availability-oracle/Chart.yaml
+++ b/charts/subgraph-availability-oracle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/subgraph-availability-oracle/README.md
+++ b/charts/subgraph-availability-oracle/README.md
@@ -2,7 +2,7 @@
 
 Deploy a Subgraph Availability Oracle into your Kubernetes stack
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/subgraph-availability-oracle/templates/subgraph-availability-oracle/servicemonitor.yaml
+++ b/charts/subgraph-availability-oracle/templates/subgraph-availability-oracle/servicemonitor.yaml
@@ -15,6 +15,7 @@ spec:
   selector:
     matchLabels:
       {{- include "subgraph-availability-oracle.selectorLabels" . | nindent 6 }}
+      serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
   endpoints:
   - port: http-metrics
     path: /

--- a/charts/subgraph-radio/Chart.yaml
+++ b/charts/subgraph-radio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.13
+version: 0.2.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -23,3 +23,4 @@ version: 0.2.13
 # It is recommended to use it with quotes.
 # renovate: image=ghcr.io/graphops/subgraph-radio
 appVersion: "1.0.6"
+

--- a/charts/subgraph-radio/README.md
+++ b/charts/subgraph-radio/README.md
@@ -2,7 +2,7 @@
 
 Deploy a Graphcast Subgraph Radio into your Kubernetes stack
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.2.13](https://img.shields.io/badge/Version-0.2.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.6](https://img.shields.io/badge/AppVersion-1.0.6-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.6](https://img.shields.io/badge/AppVersion-1.0.6-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/subgraph-radio/templates/subgraph-radio/servicemonitor.yaml
+++ b/charts/subgraph-radio/templates/subgraph-radio/servicemonitor.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "subgraph-radio.selectorLabels" . | nindent 6 }}
+      serviceMonitorTarget: "true" # Additional label to prevent matching the headless service
   endpoints:
   - port: http-metrics
     {{- with .Values.prometheus.serviceMonitors.interval }}


### PR DESCRIPTION
Closes https://github.com/graphops/production-infra/issues/574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new services in the graph network indexer and indexer tap agent.

- **Improvements**
	- Updated chart versions for multiple components to enhance stability and performance.
	- Added labels and annotations to ServiceMonitor specifications for improved monitoring capabilities.

- **Bug Fixes**
	- Enhanced service configurations for better compatibility with Kubernetes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->