### PR TITLE
feat(erigon): switchover to new repo

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,7 +35,7 @@
       // we want to exclude those
       {
         "matchPackageNames": ["erigontech/erigon"],
-        "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$"
+        "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<prerelease>\\w+\\d+))?$"
       },
       {
         "matchPackageNames": ["statusim/nimbus-eth2"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,8 +34,8 @@
       // thorax/erigon released a few versions following YYYY.MM.DD versioning pattern
       // we want to exclude those
       {
-        "matchPackageNames": ["thorax/erigon"],
-        "allowedVersions": "<2000"
+        "matchPackageNames": ["erigontech/erigon"],
+        "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$"
       },
       {
         "matchPackageNames": ["statusim/nimbus-eth2"],

--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.8-canary.1
+version: 0.10.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.7
+version: 0.10.8-canary.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-# renovate: image=thorax/erigon
+# renovate: image=erigontech/erigon
 appVersion: "2.60.8"

--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -22,4 +22,4 @@ version: 0.10.8-canary.1
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 # renovate: image=erigontech/erigon
-appVersion: "2.60.8"
+appVersion: "v2.60.9"

--- a/charts/erigon/README.md
+++ b/charts/erigon/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale [Erigon](https://github.com/ledgerwatch/erigon) inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.10.8-canary.1](https://img.shields.io/badge/Version-0.10.8--canary.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.60.8](https://img.shields.io/badge/AppVersion-2.60.8-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.10.8-canary.1](https://img.shields.io/badge/Version-0.10.8--canary.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.60.9](https://img.shields.io/badge/AppVersion-v2.60.9-informational?style=flat-square)
 
 ## Features
 

--- a/charts/erigon/README.md
+++ b/charts/erigon/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale [Erigon](https://github.com/ledgerwatch/erigon) inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.10.7](https://img.shields.io/badge/Version-0.10.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.60.8](https://img.shields.io/badge/AppVersion-2.60.8-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.10.8-canary.1](https://img.shields.io/badge/Version-0.10.8--canary.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.60.8](https://img.shields.io/badge/AppVersion-2.60.8-informational?style=flat-square)
 
 ## Features
 
@@ -123,7 +123,7 @@ We do not recommend that you upgrade the application by overriding `image.tag`. 
  | grafana.dashboardsConfigMapLabel | Must match `sidecar.dashboards.label` value for the [Grafana chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana#grafana-helm-chart) | string | `"grafana_dashboard"` |
  | grafana.dashboardsConfigMapLabelValue | Must match `sidecar.dashboards.labelValue` value for the [Grafana chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana#grafana-helm-chart) | string | `"1"` |
  | image.pullPolicy |  | string | `"IfNotPresent"` |
- | image.repository | Image for Erigon | string | `"thorax/erigon"` |
+ | image.repository | Image for Erigon | string | `"docker.io/erigontech/erigon"` |
  | image.tag | Overrides the image tag | string | Chart.appVersion |
  | imagePullSecrets | Pull secrets required to fetch the Image | list | `[]` |
  | nameOverride |  | string | `""` |

--- a/charts/erigon/values.yaml
+++ b/charts/erigon/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 
 image:
   # -- Image for Erigon
-  repository: thorax/erigon
+  repository: docker.io/erigontech/erigon
   pullPolicy: IfNotPresent
   # -- Overrides the image tag
   # @default -- Chart.appVersion


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the Erigon package rule to reflect the new source and versioning format.
	- Changed the Docker image reference for the Erigon application to the new source.
	- Expanded JWT configuration options for stateful nodes, allowing for more flexible settings.
	- Introduced a new option to expose a P2P port via NodePort.

- **Chores**
	- Minor formatting updates to configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->