### PR TITLE
feat(graph-toolbox): support aliases robustly without escaping

### DIFF
--- a/charts/graph-toolbox/Chart.yaml
+++ b/charts/graph-toolbox/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/graph-toolbox/README.md
+++ b/charts/graph-toolbox/README.md
@@ -2,7 +2,7 @@
 
 Deploy a preconfigured toolbox container for to be used alongside the Graph Network Indexer stack
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/graph-toolbox/templates/toolbox/statefulset.yaml
+++ b/charts/graph-toolbox/templates/toolbox/statefulset.yaml
@@ -53,8 +53,15 @@ spec:
             - -ac
             - |
               set -e
+              {{- if not (empty $values.aliases) }}
+              cat << 'EOF' >> ~/.bashrc
               {{- range $alias, $command := $values.aliases }}
-              echo "alias {{ $alias }}=\"{{ $command | trim }}\"" >> ~/.bashrc
+              alias {{ $alias }}=$(cat << 'EOA'
+              {{ $command | trim }}
+              EOA
+              )
+              {{- end }}
+              EOF
               {{- end }}
               mkdir -p ~/.config/graph-cli
               echo "api = '{{ required "Missing configuration" $values.config.indexer.indexerAgentManagementUrl }}'" > ~/.config/graph-cli/indexing.toml


### PR DESCRIPTION
aliases such as this were breaking and are hard to escape:
```
          aliases:
            indexer-close-all-active-allocations: >
              indexer allocations get --status active -o json | jq -r '.[] | "graph-indexer indexer actions queue unallocate \(.subgraphDeployment) \(.id) --network arbitrum-one"' | bash
```

This happens because they were then being wrapped in `echo "" >> ~/.bashrc` and executed in shell


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced container initialization with support for aliases in the startup script.
  
- **Bug Fixes**
	- Improved handling of alias definitions for a smoother startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->