### PR TITLE
fix(heimdall): fix SEEDS env var.  The heimdall.seeds helper expects …

### DIFF
--- a/charts/heimdall/templates/heimdall/statefulset.yaml
+++ b/charts/heimdall/templates/heimdall/statefulset.yaml
@@ -103,7 +103,7 @@ spec:
               mountPath: /genesis-config
           env:
             - name: SEEDS
-              value: {{ include "heimdall.seeds" . | quote }}
+              value: {{ include "heimdall.seeds" $values | quote }}
             - name: CORS_ALLOWED_ORIGINS
               value: {{ $values.config.corsAllowedOrigins | quote }}
           {{- if $values.config.metrics.enabled }}


### PR DESCRIPTION
…an object with `.config` but was being passed `.` which contains `.heimdall.config.`  Pass `$values` instead which is equal to `.heimdall`, which contains `.config`

Closes #468