### PR TITLE
fix(erigon): rm chmod from snapshot container

### DIFF
--- a/charts/erigon/templates/stateful-node/statefulset.yaml
+++ b/charts/erigon/templates/stateful-node/statefulset.yaml
@@ -138,8 +138,6 @@ spec:
               else
                 echo "Snapshot restoration not enabled, skipping..."
               fi
-              # Ensure directories are writable
-              chmod -R 777 "$STORAGE_PATH" "$CHAINDATA_PATH"
           volumeMounts:
             - name: storage
               mountPath: {{ $values.datadir }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the container initialization process by removing an explicit permission change for storage directories.
	- Maintained the existing snapshot download and restoration functionality with its error handling intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->