### PR TITLE
fix(common): cache selectively

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,4 +15,4 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-canary.1
+version: 0.0.1-canary.2


### PR DESCRIPTION
we should not be caching values in, say `global` as they can use component-dependent context like .componentName. At least not until we make this smarter.