### PR TITLE
Drop ulimits configuration

### DIFF
--- a/charts/graph-node/templates/graph-node/all.yaml
+++ b/charts/graph-node/templates/graph-node/all.yaml
@@ -133,11 +133,11 @@ spec:
                   key: {{ $val.key | quote }}
                   optional: false
           {{- end }}
+          {{- if $.Values.grafana.datasources }}
           command:
             - sh
             - -c
             - |
-              {{- if $.Values.grafana.datasources }}
               {{- if eq $groupName $.Values.grafana.datasourcesGraphNodeGroupName }}
               apply_grafana_datasources(){
               echo "Grafana Datasource creation enabled for this group, {{ $groupName }}"
@@ -195,13 +195,7 @@ spec:
               {{- else }}
               echo "Grafana Datasource creation enabled for {{ $.Values.grafana.datasourcesGraphNodeGroupName }}, not this group, {{ $groupName }}. Skipping..."
               {{- end }}
-              {{- end }}
-              set -ex
-              ulimit -n 65536
-              ulimit -a
-
-          securityContext:
-            privileged: true # required for ulimit change
+        {{- end }}
         {{- with $values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
The ulimits configuration is set from an initContainer so it has no effect on the other containers. As no command is run after this ulimits configuration, it means that it is completely useless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified graph node startup: Grafana datasource initialization now runs only when configured, removed extra shell tracing and file-descriptor tweaks, and dropped privileged init-container settings.
  * Startup sequence now proceeds directly to any additional init containers, reducing init-container overhead and improving security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/graphops/launchpad-charts/pull/651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->