### PR TITLE
fix(graph-node): useless ulimit init-container

### DIFF
--- a/charts/graph-node/Chart.yaml
+++ b/charts/graph-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.12
+version: 0.6.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/graph-node/README.md
+++ b/charts/graph-node/README.md
@@ -2,7 +2,7 @@
 
 Deploy and scale [Graph Node](https://github.com/graphprotocol/graph-node) inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.6.12](https://img.shields.io/badge/Version-0.6.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.44.0](https://img.shields.io/badge/AppVersion-v0.44.0-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.6.13](https://img.shields.io/badge/Version-0.6.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.44.0](https://img.shields.io/badge/AppVersion-v0.44.0-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/graph-node/templates/graph-node/all.yaml
+++ b/charts/graph-node/templates/graph-node/all.yaml
@@ -108,7 +108,9 @@ spec:
           configMap:
             # Provide the name of the ConfigMap you want to mount.
             name: {{ include "graph-node.fullname" . }}-config
+      {{- if or $.Values.grafana.datasources $values.extraInitContainers }}
       initContainers:
+        {{- if $.Values.grafana.datasources }}
         - name: {{ $groupName }}-init
           image: lachlanevenson/k8s-kubectl:v1.25.4
           imagePullPolicy: IfNotPresent
@@ -137,7 +139,6 @@ spec:
             - sh
             - -c
             - |
-              {{- if $.Values.grafana.datasources }}
               {{- if eq $groupName $.Values.grafana.datasourcesGraphNodeGroupName }}
               apply_grafana_datasources(){
               echo "Grafana Datasource creation enabled for this group, {{ $groupName }}"
@@ -195,16 +196,11 @@ spec:
               {{- else }}
               echo "Grafana Datasource creation enabled for {{ $.Values.grafana.datasourcesGraphNodeGroupName }}, not this group, {{ $groupName }}. Skipping..."
               {{- end }}
-              {{- end }}
-              set -ex
-              ulimit -n 65536
-              ulimit -a
-
-          securityContext:
-            privileged: true # required for ulimit change
+        {{- end }}
         {{- with $values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       containers:
         - name: {{ $groupName }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
As discussed here: https://github.com/graphops/launchpad-charts/pull/651 Addresses that properly.

Closes #651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version from 0.6.12 to 0.6.13 with corresponding documentation and badge updates
  * Improved initialization container handling in deployment templates with enhanced conditional rendering for Grafana datasource configuration and custom initialization options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->