### PR TITLE
Fix version format in erigon.json

### DIFF
--- a/charts/erigon/dashboards/erigon.json
+++ b/charts/erigon/dashboards/erigon.json
@@ -1594,6 +1594,6 @@
   "timezone": "browser",
   "title": "Erigon 3 Overview v0.9.0",
   "uid": "graphops-erigon-overview-v0_9_0",
-  "version": 090,
+  "version": 90,
   "weekStart": ""
 }


### PR DESCRIPTION
FIX: erigon.json had invalid JSON syntax and this caused the dashboard to fail to load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dashboard version metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->