### PR TITLE
feat: update erigon for multiplexed ports in 3.5.0

### DIFF
--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: erigon
-description: Deploy and scale [Erigon](https://github.com/ledgerwatch/erigon) inside Kubernetes with ease
+description: Deploy and scale [Erigon](https://github.com/erigontech/erigon) inside Kubernetes with ease
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.16
+version: 0.12.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/erigon/README.md
+++ b/charts/erigon/README.md
@@ -1,8 +1,8 @@
 # Erigon Helm Chart
 
-Deploy and scale [Erigon](https://github.com/ledgerwatch/erigon) inside Kubernetes with ease
+Deploy and scale [Erigon](https://github.com/erigontech/erigon) inside Kubernetes with ease
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.12.16](https://img.shields.io/badge/Version-0.12.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.5.0](https://img.shields.io/badge/AppVersion-v3.5.0-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.12.17](https://img.shields.io/badge/Version-0.12.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.5.0](https://img.shields.io/badge/AppVersion-v3.5.0-informational?style=flat-square)
 
 ## Features
 
@@ -82,9 +82,11 @@ By default, your Erigon node will not have an internet-accessible port for P2P t
 To expose P2P you can now use either NodePort or LoadBalancer:
 
 - NodePort (legacy and default behavior when enabled): set `statefulNode.p2p.service.enabled=true` and `statefulNode.p2p.service.type=NodePort` (or `statefulNode.p2pNodePort.enabled=true` for backwards compatibility). This mode locks `statefulNode.replicaCount` to `1` and uses an initContainer to discover the Node's external IP for correct ENR advertisement.
-- LoadBalancer: set `statefulNode.p2p.service.enabled=true` and `statefulNode.p2p.service.type=LoadBalancer`. You can add cloud-specific annotations via `statefulNode.p2p.service.annotations` and the P2P Service ports will match the container P2P flags.
+- LoadBalancer: set `statefulNode.p2p.service.enabled=true` and `statefulNode.p2p.service.type=LoadBalancer`. You can add cloud-specific annotations via `statefulNode.p2p.service.annotations` and the P2P Service port will match the container P2P flag.
 
-Note: `statefulNode.p2pNodePort.*` remains supported for backwards compatibility, but `statefulNode.p2p.service.*` is preferred going forward.
+Erigon v3.5+ multiplexes all eth protocol versions on a single `--port` listener. The chart exposes one TCP/UDP P2P port pair and no longer renders `--p2p.allowed-ports`.
+
+Note: `statefulNode.p2pNodePort.*` remains supported for backwards compatibility, but `statefulNode.p2p.service.*` is preferred going forward. `statefulNode.p2p.allowedPorts` is deprecated; when set, only its first value is used.
 
 ```yaml
 # values.yaml
@@ -194,7 +196,8 @@ We do not recommend that you upgrade the application by overriding `image.tag`. 
  | statefulNode.jwt.fromLiteral | Use this literal value for the JWT | string | `nil` |
  | statefulNode.livenessProbe | Sets a livenessProbe configuration for the container | object | `{}` |
  | statefulNode.nodeSelector |  | object | `{}` |
- | statefulNode.p2p.allowedPorts | Two explicit P2P ports to allow (protocol 68,67). Services and container ports will match these.    If not set, defaults to [30303, 30304]. | list | `[30303,30304]` |
+ | statefulNode.p2p.allowedPorts | Deprecated compatibility setting. When non-empty, only the first port is used as the P2P listener port. | list | `[]` |
+ | statefulNode.p2p.port | P2P listener port. Erigon v3.5+ multiplexes all eth protocol versions on this single port. | int | `30303` |
  | statefulNode.p2p.service.advertiseIP | IP address to explicitly advertise on the P2P network (overrides autodetection and LB IP) | string | `""` |
  | statefulNode.p2p.service.annotations | Annotations to add to the P2P Service (useful for cloud LBs) | object | `{}` |
  | statefulNode.p2p.service.enabled | Enable creation of a P2P Service | bool | `false` |
@@ -204,14 +207,14 @@ We do not recommend that you upgrade the application by overriding `image.tag`. 
  | statefulNode.p2p.service.labels | Additional labels to add to the P2P Service | object | `{}` |
  | statefulNode.p2p.service.loadBalancerIP | When using a LoadBalancer and your cloud supports it, reserve a specific IP | string | `""` |
  | statefulNode.p2p.service.loadBalancerSourceRanges | Restrict which source ranges can access the LoadBalancer (CIDRs) | list | `[]` |
- | statefulNode.p2p.service.nodePort | When type is NodePort, base nodePort to use (port and port+1 are used) | object | `{"base":31000}` |
+ | statefulNode.p2p.service.nodePort | When type is NodePort, nodePort to use for the single multiplexed P2P listener | object | `{"base":31000}` |
  | statefulNode.p2p.service.publishNotReadyAddresses | Toggle publishing not ready addresses for p2p service | bool | `false` |
  | statefulNode.p2p.service.type | Service type for P2P exposure (NodePort or LoadBalancer) | string | `"NodePort"` |
  | statefulNode.p2pNodePort.enabled | Expose P2P port via NodePort | bool | `false` |
  | statefulNode.p2pNodePort.initContainer.image.pullPolicy | Container pull policy | string | `"IfNotPresent"` |
  | statefulNode.p2pNodePort.initContainer.image.repository | Container image to fetch nodeport information | string | `"lachlanevenson/k8s-kubectl"` |
  | statefulNode.p2pNodePort.initContainer.image.tag | Container tag | string | `"v1.25.4"` |
- | statefulNode.p2pNodePort.port | Start NodePort to be used in a range (2 ports for protocol versions 68 and 67). Must be unique. | int | `31000` |
+ | statefulNode.p2pNodePort.port | NodePort to use for the single multiplexed P2P listener. Must be unique. | int | `31000` |
  | statefulNode.podAnnotations | Annotations for the `Pod` | object | `{}` |
  | statefulNode.podSecurityContext | Pod-wide security context | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` |
  | statefulNode.privateApi.ratelimit |  | int | `31872` |

--- a/charts/erigon/README.md.gotmpl
+++ b/charts/erigon/README.md.gotmpl
@@ -82,9 +82,11 @@ By default, your Erigon node will not have an internet-accessible port for P2P t
 To expose P2P you can now use either NodePort or LoadBalancer:
 
 - NodePort (legacy and default behavior when enabled): set `statefulNode.p2p.service.enabled=true` and `statefulNode.p2p.service.type=NodePort` (or `statefulNode.p2pNodePort.enabled=true` for backwards compatibility). This mode locks `statefulNode.replicaCount` to `1` and uses an initContainer to discover the Node's external IP for correct ENR advertisement.
-- LoadBalancer: set `statefulNode.p2p.service.enabled=true` and `statefulNode.p2p.service.type=LoadBalancer`. You can add cloud-specific annotations via `statefulNode.p2p.service.annotations` and the P2P Service ports will match the container P2P flags.
+- LoadBalancer: set `statefulNode.p2p.service.enabled=true` and `statefulNode.p2p.service.type=LoadBalancer`. You can add cloud-specific annotations via `statefulNode.p2p.service.annotations` and the P2P Service port will match the container P2P flag.
 
-Note: `statefulNode.p2pNodePort.*` remains supported for backwards compatibility, but `statefulNode.p2p.service.*` is preferred going forward.
+Erigon v3.5+ multiplexes all eth protocol versions on a single `--port` listener. The chart exposes one TCP/UDP P2P port pair and no longer renders `--p2p.allowed-ports`.
+
+Note: `statefulNode.p2pNodePort.*` remains supported for backwards compatibility, but `statefulNode.p2p.service.*` is preferred going forward. `statefulNode.p2p.allowedPorts` is deprecated; when set, only its first value is used.
 
 ```yaml
 # values.yaml

--- a/charts/erigon/templates/_helpers.tpl
+++ b/charts/erigon/templates/_helpers.tpl
@@ -68,9 +68,13 @@ Create the name of the service account to use
 {{/*
 P2P helpers
 */}}
-{{- define "erigon.p2p.nodePortBase" -}}
+{{- define "erigon.p2p.nodePort" -}}
 {{- $values := . -}}
-{{- if and $values.p2p $values.p2p.service $values.p2p.service.nodePort $values.p2p.service.nodePort.base -}}
+{{- if and $values.p2p $values.p2p.allowedPorts (gt (len $values.p2p.allowedPorts) 0) -}}
+{{- index $values.p2p.allowedPorts 0 -}}
+{{- else if and $values.p2p $values.p2p.service $values.p2p.service.nodePort $values.p2p.service.nodePort.port -}}
+{{- $values.p2p.service.nodePort.port -}}
+{{- else if and $values.p2p $values.p2p.service $values.p2p.service.nodePort $values.p2p.service.nodePort.base -}}
 {{- $values.p2p.service.nodePort.base -}}
 {{- else if and $values.p2pNodePort $values.p2pNodePort.port -}}
 {{- $values.p2pNodePort.port -}}
@@ -80,36 +84,16 @@ P2P helpers
 {{- end -}}
 
 {{/*
-Erigon P2P ports: two explicit ports (protocol 68 and 67)
+Erigon v3.5+ multiplexes all eth protocol versions on one P2P port.
 */}}
-{{- define "erigon.p2p.port1" -}}
+{{- define "erigon.p2p.containerPort" -}}
 {{- $v := . -}}
-{{- if and $v.p2p $v.p2p.allowedPorts -}}
+{{- if and $v.p2p $v.p2p.allowedPorts (gt (len $v.p2p.allowedPorts) 0) -}}
   {{- index $v.p2p.allowedPorts 0 -}}
+{{- else if and $v.p2p $v.p2p.port -}}
+  {{- $v.p2p.port -}}
 {{- else -}}
-  {{- include "erigon.p2p.containerPortBase" $v -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "erigon.p2p.port2" -}}
-{{- $v := . -}}
-{{- if and $v.p2p $v.p2p.allowedPorts -}}
-  {{- if ge (len $v.p2p.allowedPorts) 2 -}}
-    {{- index $v.p2p.allowedPorts 1 -}}
-  {{- else -}}
-    {{- add (include "erigon.p2p.containerPortBase" $v | int) 1 -}}
-  {{- end -}}
-{{- else -}}
-  {{- add (include "erigon.p2p.containerPortBase" $v | int) 1 -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "erigon.p2p.containerPortBase" -}}
-{{- $values := . -}}
-{{- if and $values.p2p $values.p2p.port -}}
-{{- $values.p2p.port -}}
-{{- else -}}
-30303
+  30303
 {{- end -}}
 {{- end -}}
 
@@ -139,9 +123,9 @@ false
 
 {{- define "erigon.p2pPort" -}}
 {{- if (include "erigon.p2p.isNodePort" . | trim | eq "true") -}}
-{{- include "erigon.p2p.nodePortBase" . -}}
+{{- include "erigon.p2p.nodePort" . -}}
 {{- else -}}
-{{- include "erigon.p2p.containerPortBase" . -}}
+{{- include "erigon.p2p.containerPort" . -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/erigon/templates/stateful-node/service.yaml
+++ b/charts/erigon/templates/stateful-node/service.yaml
@@ -52,8 +52,7 @@ spec:
     {{- $componentLabel | nindent 4 }}
 {{/* P2P Service when NodePort is enabled (legacy or new config) */}}
 {{- if (include "erigon.p2p.isNodePort" $values | trim | eq "true") }}
-{{- $p1 := (include "erigon.p2p.port1" $values) | int }}
-{{- $p2 := (include "erigon.p2p.port2" $values) | int }}
+{{- $p2pPort := (include "erigon.p2pPort" $values) | int }}
 ---
 apiVersion: v1
 kind: Service
@@ -76,26 +75,16 @@ spec:
     {{- toYaml $values.p2p.service.externalIPs | nindent 2 }}
   {{- end }}
   ports:
-    - name: tcp-p2p-68
-      port: {{ $p1 }}
+    - name: tcp-p2p
+      port: {{ $p2pPort }}
       protocol: TCP
-      targetPort: tcp-p2p-68
-      nodePort: {{ $p1 }}
-    - name: udp-p2p-68
-      port: {{ $p1 }}
+      targetPort: tcp-p2p
+      nodePort: {{ $p2pPort }}
+    - name: udp-p2p
+      port: {{ $p2pPort }}
       protocol: UDP
-      targetPort: udp-p2p-68
-      nodePort: {{ $p1 }}
-    - name: tcp-p2p-67
-      port: {{ $p2 }}
-      protocol: TCP
-      targetPort: tcp-p2p-67
-      nodePort: {{ $p2 }}
-    - name: udp-p2p-67
-      port: {{ $p2 }}
-      protocol: UDP
-      targetPort: udp-p2p-67
-      nodePort: {{ $p2 }}
+      targetPort: udp-p2p
+      nodePort: {{ $p2pPort }}
   selector:
     {{- include "erigon.selectorLabels" . | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "erigon.fullname" $ }}-{{ $componentName }}-0"
@@ -136,22 +125,14 @@ spec:
   {{- end }}
   publishNotReadyAddresses: {{ if (and $values.p2p $values.p2p.service) }}{{ default false $values.p2p.service.publishNotReadyAddresses }}{{ else }}{{ default false $values.service.publishNotReadyAddresses.p2p }}{{ end }}
   ports:
-    - name: tcp-p2p-68
-      port: {{ include "erigon.p2p.port1" $values }}
+    - name: tcp-p2p
+      port: {{ include "erigon.p2pPort" $values }}
       protocol: TCP
-      targetPort: tcp-p2p-68
-    - name: udp-p2p-68
-      port: {{ include "erigon.p2p.port1" $values }}
+      targetPort: tcp-p2p
+    - name: udp-p2p
+      port: {{ include "erigon.p2pPort" $values }}
       protocol: UDP
-      targetPort: udp-p2p-68
-    - name: tcp-p2p-67
-      port: {{ include "erigon.p2p.port2" $values }}
-      protocol: TCP
-      targetPort: tcp-p2p-67
-    - name: udp-p2p-67
-      port: {{ include "erigon.p2p.port2" $values }}
-      protocol: UDP
-      targetPort: udp-p2p-67
+      targetPort: udp-p2p
   selector:
     {{- include "erigon.selectorLabels" . | nindent 4 }}
     {{- $componentLabel | nindent 4 }}

--- a/charts/erigon/templates/stateful-node/statefulset.yaml
+++ b/charts/erigon/templates/stateful-node/statefulset.yaml
@@ -5,6 +5,11 @@
 {{- $jwtEnabled := or $values.jwt.existingSecret.name $values.jwt.fromLiteral }}
 {{- $jwtSecretName := default (print (include "erigon.fullname" .) "-" $componentName "-jwt") $values.jwt.existingSecret.name }}
 {{- $jwtSecretKey := default "jwt.hex" $values.jwt.existingSecret.key }}
+{{- $p2pIsNodePort := include "erigon.p2p.isNodePort" $values | trim | eq "true" }}
+{{- $p2pInitImage := $values.p2pNodePort.initContainer.image }}
+{{- if and $values.p2p $values.p2p.service $values.p2p.service.initContainer $values.p2p.service.initContainer.image }}
+{{- $p2pInitImage = $values.p2p.service.initContainer.image }}
+{{- end }}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -68,7 +73,7 @@ spec:
               - key: {{ $jwtSecretKey }}
                 path: jwt.hex
       {{- end }}
-      {{- if $values.p2pNodePort.enabled }}
+      {{- if $p2pIsNodePort }}
         - name: env-nodeport
           emptyDir: {}
       {{- end }}
@@ -94,10 +99,10 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: "/storage"
-      {{- if $values.p2pNodePort.enabled }}
+      {{- if $p2pIsNodePort }}
         - name: init-nodeport
-          image: "{{ $values.p2pNodePort.initContainer.image.repository }}:{{ $values.p2pNodePort.initContainer.image.tag }}"
-          imagePullPolicy: {{ $values.p2pNodePort.initContainer.image.pullPolicy }}
+          image: "{{ $p2pInitImage.repository }}:{{ $p2pInitImage.tag }}"
+          imagePullPolicy: {{ $p2pInitImage.pullPolicy }}
           securityContext:
             runAsNonRoot: false
             runAsUser: 0
@@ -117,8 +122,7 @@ spec:
             - -c
             - |
               set -ex;
-              export EXTERNAL_PORT_68=$(kubectl get services -l "pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[?(@.name=="tcp-p2p-68")].nodePort}');
-              export EXTERNAL_PORT_67=$(kubectl get services -l "pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[?(@.name=="tcp-p2p-67")].nodePort}');
+              export EXTERNAL_PORT=$(kubectl get services -l "pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[?(@.name=="tcp-p2p")].nodePort}');
               export EXTERNAL_IP=$(kubectl get nodes "${NODE_NAME}" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}');
               until [ -n "$EXTERNAL_IP" ]; do
                 for SITE in $SITES; do
@@ -137,8 +141,7 @@ spec:
                 fi
               done
               export EXTERNAL_IP=${EXTERNAL_IP:-"UNAVAILABLE"};
-              echo "EXTERNAL_PORT_68=$EXTERNAL_PORT_68" >  /env/init-nodeport;
-              echo "EXTERNAL_PORT_67=$EXTERNAL_PORT_67" >>  /env/init-nodeport;
+              echo "EXTERNAL_PORT=$EXTERNAL_PORT" >  /env/init-nodeport;
               echo "EXTERNAL_IP=$EXTERNAL_IP"     >> /env/init-nodeport;
               cat /env/init-nodeport;
           volumeMounts:
@@ -161,7 +164,7 @@ spec:
             - sh
             - -ac
             - |
-            {{- if $values.p2pNodePort.enabled }}
+            {{- if $p2pIsNodePort }}
               . /env/init-nodeport;
             {{- if and $values.p2p $values.p2p.service $values.p2p.service.advertiseIP }}
               EXTERNAL_IP={{ $values.p2p.service.advertiseIP }};
@@ -170,17 +173,16 @@ spec:
               set -ex;
               exec erigon \
                 --datadir={{ $values.datadir }} \
-              {{- if $values.p2pNodePort.enabled }}
+              {{- if $p2pIsNodePort }}
                 --nat=extip:${EXTERNAL_IP} \
-                --port=${EXTERNAL_PORT_68} \
-                --p2p.allowed-ports="${EXTERNAL_PORT_68},${EXTERNAL_PORT_67}" \
+                --port=${EXTERNAL_PORT} \
               {{- else }}
               {{- if and $values.p2p $values.p2p.service $values.p2p.service.advertiseIP }}
                 --nat=extip:{{ $values.p2p.service.advertiseIP }} \
               {{- else if (and $values.p2p $values.p2p.service (eq $values.p2p.service.type "LoadBalancer") $values.p2p.service.loadBalancerIP) }}
                 --nat=extip:{{ $values.p2p.service.loadBalancerIP }} \
               {{- end }}
-                --p2p.allowed-ports="{{ include "erigon.p2p.port1" $values }},{{ include "erigon.p2p.port2" $values }}" \
+                --port={{ include "erigon.p2pPort" $values }} \
               {{- end }}
                 --private.api.addr=0.0.0.0:{{ index $values.service.ports "grpc-erigon" }} \
                 --http \
@@ -239,17 +241,11 @@ spec:
               containerPort: {{ $values.beaconApi.port }}
               protocol: TCP
             {{- end }}
-            - name: udp-p2p-68
-              containerPort: {{ include "erigon.p2p.port1" $values }}
+            - name: udp-p2p
+              containerPort: {{ include "erigon.p2pPort" $values }}
               protocol: UDP
-            - name: tcp-p2p-68
-              containerPort: {{ include "erigon.p2p.port1" $values }}
-              protocol: TCP
-            - name: udp-p2p-67
-              containerPort: {{ include "erigon.p2p.port2" $values }}
-              protocol: UDP
-            - name: tcp-p2p-67
-              containerPort: {{ include "erigon.p2p.port2" $values }}
+            - name: tcp-p2p
+              containerPort: {{ include "erigon.p2pPort" $values }}
               protocol: TCP
             - name: udp-torrent
               containerPort: 42069
@@ -258,7 +254,7 @@ spec:
               containerPort: 42069
               protocol: TCP
           volumeMounts:
-            {{- if $values.p2pNodePort.enabled }}
+            {{- if $p2pIsNodePort }}
             - name: env-nodeport
               mountPath: /env
             {{- end }}

--- a/charts/erigon/values.yaml
+++ b/charts/erigon/values.yaml
@@ -242,9 +242,10 @@ statefulNode:
     ratelimit: 31872
   # P2P configuration (supersedes p2pNodePort)
   p2p:
-    # -- Two explicit P2P ports to allow (protocol 68,67). Services and container ports will match these.
-    #    If not set, defaults to [30303, 30304].
-    allowedPorts: [30303, 30304]
+    # -- P2P listener port. Erigon v3.5+ multiplexes all eth protocol versions on this single port.
+    port: 30303
+    # -- Deprecated compatibility setting. When non-empty, only the first port is used as the P2P listener port.
+    allowedPorts: []
     service:
       # -- Enable creation of a P2P Service
       enabled: false
@@ -266,7 +267,7 @@ statefulNode:
       loadBalancerSourceRanges: []
       # -- IP address to explicitly advertise on the P2P network (overrides autodetection and LB IP)
       advertiseIP: ""
-      # -- When type is NodePort, base nodePort to use (port and port+1 are used)
+      # -- When type is NodePort, nodePort to use for the single multiplexed P2P listener
       nodePort:
         base: 31000
       # -- (Advanced) override initContainer image used in NodePort mode
@@ -279,7 +280,7 @@ statefulNode:
   p2pNodePort:
     # -- Expose P2P port via NodePort
     enabled: false
-    # -- Start NodePort to be used in a range (2 ports for protocol versions 68 and 67). Must be unique.
+    # -- NodePort to use for the single multiplexed P2P listener. Must be unique.
     port: 31000
     initContainer:
       image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Erigon chart now uses a single multiplexed P2P listener port, simplifying network exposure for newer releases.

* **Bug Fixes**
  * Updated NodePort and LoadBalancer behavior to use consistent P2P ports.
  * Improved handling of older P2P port settings by treating them as deprecated compatibility options.

* **Documentation**
  * Refreshed chart docs and examples to match the latest chart version and current P2P networking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->